### PR TITLE
[HOTFIX] Deleted Procfile and updated Resque initializer to consider Prod config variable on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-resque: QUEUE=* bundle exec rake resque:work
-scheduler: bundle exec rake resque:scheduler

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,1 +1,10 @@
+require 'resque/server'
+
 Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")
+
+if Rails.env.development?
+  Resque.redis = Redis.new(host: 'localhost', port: '6379')
+else
+  uri = URI.parse(ENV['REDIS_URL'])
+  Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
+end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,10 +1,13 @@
 require 'resque/server'
+require 'uri'
 
 Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")
 
 if Rails.env.development?
   Resque.redis = Redis.new(host: 'localhost', port: '6379')
 else
-  uri = URI.parse(ENV['REDIS_URL'])
+  uri = URI.parse(URI.encode((ENV['REDIS_URL']).to_s))
+  # Resque.redis = Redis.new(host: 'localhost', port: '6379')
   Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
+  
 end


### PR DESCRIPTION
### Deleted procfile since this might be the one causing migration issue

### Added Redis Prod Heroku env variable to resque initializer

```
require 'resque/server'

Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")

if Rails.env.development?
  Resque.redis = Redis.new(host: 'localhost', port: '6379')
else
  uri = URI.parse(ENV['REDIS_URL'])
  Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
end
```
