### PR TITLE
[HOTFIX] added config.assets.initialize_on_precompile = false in application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module RailsProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-
+    config.assets.initialize_on_precompile = false
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
It seems that initializers are being triggered on asset precompile. Let's try to disable this to pushthrough migration