### PR TITLE
[HOTFIX] Fixes on Heroku deployment. Added Procfile for Heroku run.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'hamlit-rails'
 gem 'inline_svg'
 gem 'resque'
 gem 'resque-scheduler'
-gem 'redis'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 5.0', '>= 5.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,6 @@ DEPENDENCIES
   pg
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
-  redis
   resque
   resque-scheduler
   rspec-rails (~> 5.0, >= 5.0.2)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+resque: QUEUE=* bundle exec rake schedule_and_work

--- a/Rakefile
+++ b/Rakefile
@@ -12,19 +12,19 @@ namespace :resque do
 
   task setup_schedule: :setup do
     require 'resque-scheduler'
-    Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")
+    Resque.schedule = YAML.load_file(Rails.root.join('/config/resque_schedule.yml'))
   end
 
   task scheduler: :setup_schedule
 end
 
 # Scheduler needs very little cpu, just start it with a worker.
-desc "schedule and work, so we only need 1 dyno"
-task :schedule_and_work do
+desc 'schedule and work, so we only need 1 dyno'
+task schedule_and_work: :environment do
   if Process.fork
-    sh "rake environment resque:work"
+    sh 'rake environment resque:work'
   else
-    sh "rake resque:scheduler"
+    sh 'rake resque:scheduler'
     Process.wait
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,15 @@ namespace :resque do
   task scheduler: :setup_schedule
 end
 
+# Scheduler needs very little cpu, just start it with a worker.
+desc "schedule and work, so we only need 1 dyno"
+task :schedule_and_work do
+  if Process.fork
+    sh "rake environment resque:work"
+  else
+    sh "rake resque:scheduler"
+    Process.wait
+  end
+end
+
 Rails.application.load_tasks

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ namespace :resque do
 
   task setup_schedule: :setup do
     require 'resque-scheduler'
+    Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")
   end
 
   task scheduler: :setup_schedule

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,6 @@ module RailsProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    config.assets.initialize_on_precompile = false
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,0 @@
-$redis = Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,11 +1,15 @@
 require 'resque/server'
+require 'resque'
 require 'uri'
 
 Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")
 
 if Rails.env.development?
-  Resque.redis = Redis.new(host: 'localhost', port: '6379')
-else
+  puts "resque development"
+  Resque.redis = Redis.new(host: 'localhost', port: '1231')
+end
+if Rails.env.production?
+  puts "resque production"
   uri = URI.parse(Rails.application.credentials.redis_heroku[:REDIS_URL])
   Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -2,7 +2,7 @@ require 'resque/server'
 require 'uri'
 
 if Rails.env.development?
-  Resque.redis = Redis.new(host: 'localhost', port: '1231')
+  Resque.redis = Redis.new(host: 'localhost', port: '6379')
 else
   uri = URI.parse(Rails.application.credentials.redis_heroku[:REDIS_URL])
   Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,15 +1,9 @@
 require 'resque/server'
-require 'resque'
 require 'uri'
 
-Resque.schedule = YAML.load_file("#{Rails.root}/config/resque_schedule.yml")
-
 if Rails.env.development?
-  puts "resque development"
   Resque.redis = Redis.new(host: 'localhost', port: '1231')
-end
-if Rails.env.production?
-  puts "resque production"
+else
   uri = URI.parse(Rails.application.credentials.redis_heroku[:REDIS_URL])
   Resque.redis = Redis.new(host: uri.host, port: uri.port, password: uri.password)
 end


### PR DESCRIPTION
### Removed Redis gem and redis.rb under initializer
This was not needed at all when I included in previous PR

### Removed Resque scheduler from resque under initializer
This was the rootcause of errors during migration. It seems that files under initializer are being run during pre-compile. That is why it is looking for a redis server even though it was not yet initialized at first.

Solution is to move the Resque scheduler under Rakefile instead.

### Removed precompile false
Just undoing the PR I did earlier for a hotfix. It turns out that this is not needed.

### Added Procfile for Heroku
In order to run resque, I added a Procfile so we can run it under a dyno.
Maximum of 2 dynos are allowed in Heroku (server start and resque)

