### PR TITLE
[HOTFIX] minor fix on path under Rails.root for finding scheduler.yml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ namespace :resque do
 
   task setup_schedule: :setup do
     require 'resque-scheduler'
-    Resque.schedule = YAML.load_file(Rails.root.join('/config/resque_schedule.yml'))
+    Resque.schedule = YAML.load_file(Rails.root.join('config/resque_schedule.yml'))
   end
 
   task scheduler: :setup_schedule


### PR DESCRIPTION
changed to : Resque.schedule = YAML.load_file(Rails.root.join('config/resque_schedule.yml')) as heroku seems to not find the file with a prefixed '/'

![image](https://user-images.githubusercontent.com/5262223/134254613-7d71b4a3-db10-4a81-a186-9dcbac40db8c.png)
