### PR TITLE
[HOT-FIX] - Missing histories table migration file

### DIFF
--- a/db/migrate/20210924115750_history.rb
+++ b/db/migrate/20210924115750_history.rb
@@ -1,0 +1,14 @@
+class History < ActiveRecord::Migration[6.0]
+  def change
+    create_table :histories do |t|
+    t.integer :user_id
+      t.integer :portfolio_id
+      t.string :type
+      t.string :market_symbol
+      t.float :curr_stock_price
+      t.float :amount
+
+      t.timestamps
+  end
+end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_23_230836) do
+ActiveRecord::Schema.define(version: 2021_09_24_115750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,17 @@ ActiveRecord::Schema.define(version: 2021_09_23_230836) do
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
+  create_table "histories", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "portfolio_id"
+    t.string "type"
+    t.string "market_symbol"
+    t.float "curr_stock_price"
+    t.float "amount"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "markets", force: :cascade do |t|
     t.string "market_symbol"
     t.integer "curr_price"
@@ -42,10 +53,9 @@ ActiveRecord::Schema.define(version: 2021_09_23_230836) do
     t.string "market_symbol"
     t.float "hist_price"
     t.float "amount"
-    t.integer "market_id"
+    t.integer "sample_stock_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "transaction_type"
     t.float "units"
   end
 


### PR DESCRIPTION
> Generated a migration file for histories which is missing. 
> The missing files caused an error when migrating because we have the drop histories table migration file.